### PR TITLE
Run CSVUploader synchronously

### DIFF
--- a/lib/csm_sync/workers/csv_writer.rb
+++ b/lib/csm_sync/workers/csv_writer.rb
@@ -16,8 +16,10 @@ module CSMSync
 
           if CSV.new(contacts.map(&:csv_attributes), file_path).save!
             Log.info "#{contacts.length} contacts saved to #{file_path}"
-            sleep 2 # give the file time to be written before uploading it
-            CSVUploader.perform_async(file_path)
+            # It would be nice to run this asynchronously but in a load balanced situation
+            # we can't guarantee that the file wasn't written onto a different server.
+            # Until we have a shared files directory, this is the best workaround.
+            CSVUploader.new.perform(file_path)
           end
         else
           Log.warn "Worker is disabled"


### PR DESCRIPTION
Having two workers is a nice pattern but it causes problemse when there are more than one sidekiq server and they don't share a files directory. For now the best solution is to run CSVUploader synchronously.